### PR TITLE
Not redirecting typo issue(#2) resolved

### DIFF
--- a/shortner/views.py
+++ b/shortner/views.py
@@ -10,6 +10,8 @@ def index(request):
 def create(request):
     if request.method == 'POST':
         link = request.POST['link']
+        if ("http://" not in link) and ("https://" not in link) :
+                link = "http://" + link
         uid = str(uuid.uuid4())[:5]
         new_url = Url(link=link,uuid=uid)
         new_url.save()
@@ -17,4 +19,5 @@ def create(request):
 
 def go(request, pk):
     url_details = Url.objects.get(uuid=pk)
-    return redirect('https://'+url_details.link)
+    print(url_details.link)
+    return redirect(url_details.link)


### PR DESCRIPTION
Input link: https://www.youtube.com/techwithrvr?sub_confirmation=1
Shortern link: www.surls.ga/7217a

But really, this link redirects
https://https//www.youtube.com/techwithrvr?sub_confirmation=1

See at the starting of the above link there is a mistake. So to correct this error, I checked the link to see if it had "http://" or "https://" in it. If the substring does not exist, "http://" will be inserted at the beginning of the link. Also, deleted the 'https://' from line number 20. Since it used to add twice. This has resolved the problem.

I hope you are going to accept this pull request.